### PR TITLE
production環境ではopen api ui等を表示しない

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,9 @@ OPENAI_API_KEY=
 PUBLIC_API_KEY=public
 # client-adminからAPIにアクセスする際のAPIキー。サーバー側でセットされる。NEXT_PUBLIC_ADMIN_API_KEYと同じ値を設定。
 ADMIN_API_KEY=admin
+# productionかdevelopmentを設定。productionの場合はopenapi等のUIが表示されなくなる。
+ENVIRONMENT=development
+
 
 # clientでセットが必要な環境変数
 # clientからAPIにアクセスする際のAPIキー。ローカルで起動する場合は変更不要。クラウド等でホスティングする場合は値を変更。

--- a/compose.yaml
+++ b/compose.yaml
@@ -8,7 +8,6 @@ services:
     volumes:
       - ./server:/app
     environment:
-      - ENVIRONMENT=development
       - LOG_LEVEL=debug
     env_file:
       - .env

--- a/server/src/config.py
+++ b/server/src/config.py
@@ -1,14 +1,18 @@
 import os
 from pathlib import Path
+from typing import Literal
 
 from pydantic import Field
 from pydantic_settings import BaseSettings
+
+Environment = Literal["development", "production"]
 
 
 class Settings(BaseSettings):
     ADMIN_API_KEY: str = Field(env="ADMIN_API_KEY")
     PUBLIC_API_KEY: str = Field(env="PUBLIC_API_KEY")
     OPENAI_API_KEY: str = Field(env="OPENAI_API_KEY")
+    ENVIRONMENT: Environment = Field(env="ENVIRONMENT", default="production")
     BASE_DIR: Path = Path(__file__).parent.parent
     TOOL_DIR: Path = BASE_DIR / "broadlistening"
     REPORT_DIR: Path = TOOL_DIR / "pipeline" / "outputs"

--- a/server/src/main.py
+++ b/server/src/main.py
@@ -3,6 +3,7 @@ from contextlib import asynccontextmanager
 from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import ORJSONResponse
+from src.config import settings
 from src.middleware.security_middleware import register_security_middleware
 from src.routers import router
 from src.services.report_status import load_status
@@ -11,17 +12,32 @@ from src.utils.logger import setup_logger
 slogger = setup_logger()
 
 
+def get_app():
+    print(settings.ENVIRONMENT)
+    if settings.ENVIRONMENT == "production":
+        return FastAPI(
+            title="kouchou-ai API",
+            default_response_class=ORJSONResponse,
+            lifespan=lifespan,
+            openapi_url=None,
+            docs_url=None,
+            redoc_url=None,
+        )
+    else:
+        return FastAPI(
+            title="kouchou-ai API",
+            default_response_class=ORJSONResponse,
+            lifespan=lifespan,
+        )
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     load_status()
     yield
 
 
-app = FastAPI(
-    title="kouchou-ai API",
-    default_response_class=ORJSONResponse,
-    lifespan=lifespan,
-)
+app = get_app()
 
 app.add_middleware(
     CORSMiddleware,


### PR DESCRIPTION
# 変更の概要
* 環境(development/production)を示す環境変数を追加
* productionの場合はopenapi等のuiを表示しないように修正

# 変更の背景
* 本番環境において、APIの情報を表示させたくない

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました