### PR TITLE
fix: 環境変数 BASIC_AUTH_* に値を設定しない場合でも Basic 認証が求められてしまう

### DIFF
--- a/client-admin/middleware.ts
+++ b/client-admin/middleware.ts
@@ -3,7 +3,9 @@ import {NextRequest, NextResponse} from 'next/server'
 export function middleware(req: NextRequest) {
   if (
     process.env.BASIC_AUTH_USERNAME === undefined ||
-    process.env.BASIC_AUTH_PASSWORD === undefined
+    process.env.BASIC_AUTH_PASSWORD === undefined ||
+    process.env.BASIC_AUTH_USERNAME === '' ||
+    process.env.BASIC_AUTH_PASSWORD === ''
   ) {
     return NextResponse.next()
   }


### PR DESCRIPTION
# 変更の概要

環境変数 BASIC_AUTH_USERNAME, BASIC_AUTH_PASSWORD が空文字列の場合も Basic 認証をスキップするようにします

# 変更の背景
#63 環境変数がセットされていない場合でも、認証がスキップされない

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました