### PR TITLE
fix: docker-composeで起動した際に、clientで一部の画像が表示されない

### DIFF
--- a/client/components/Header.tsx
+++ b/client/components/Header.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import {Box, HStack, Image, Text} from '@chakra-ui/react'
 import {XIcon} from 'lucide-react'
 import {BroadlisteningGuide} from '@/components/report/BroadlisteningGuide'


### PR DESCRIPTION
# 変更の概要
- fixes https://github.com/takahiroanno2024/kouchou-ai/issues/45

docker compose で起動すると、Header コンポーネントの画像のパスが `http://api:8000/meta/reporter.png` を指していて、適切に画像が表示されない課題を修正しました。

# 変更の背景
- 原因: Header コンポーネントが Server Component としてレンダリングされるため、[画像のパスを取得する際に利用する関数内で `http://api:8000` が Base URL として返されている](https://github.com/takahiroanno2024/kouchou-ai/blob/9e2c9f64f2806bee5946e6939157b3541178b5a8/client/app/utils/api.ts#L6-L8)
- 修正方針: Header コンポーネントを Client Component としてレンダリングすることで、期待した Base URL を取得できるようにする
  - Header コンポーネントと同じ画像を参照している [About コンポーネントが Client Component](https://github.com/takahiroanno2024/kouchou-ai/blob/9e2c9f64f2806bee5946e6939157b3541178b5a8/client/components/About.tsx#L1-L24) で適切にレンダリングできていたので、そちらに寄せました

## Before
![image](https://github.com/user-attachments/assets/312927b9-82b6-49dc-b145-57422ebaf6a8)

## After
![image](https://github.com/user-attachments/assets/9a4f82d7-e64d-4c09-91a6-0eb52bfacb05)


# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました