### PR TITLE
レポート生成失敗時のレポート一覧画面の表示を調整

### DIFF
--- a/client-admin/app/page.tsx
+++ b/client-admin/app/page.tsx
@@ -4,7 +4,7 @@ import {Header} from '@/components/Header'
 import {Report} from '@/type'
 import {Box, Button, Card, Heading, HStack, Spinner, Text, VStack} from '@chakra-ui/react'
 import Link from 'next/link'
-import {CircleCheckIcon, CircleFadingArrowUpIcon, EllipsisIcon, ExternalLinkIcon} from 'lucide-react'
+import {CircleCheckIcon, CircleFadingArrowUpIcon, CircleAlertIcon, EllipsisIcon, ExternalLinkIcon} from 'lucide-react'
 import {MenuContent, MenuItem, MenuRoot, MenuTrigger} from '@/components/ui/menu'
 import {useEffect, useState} from 'react'
 
@@ -46,20 +46,30 @@ export default function Page() {
             key={report.slug}
             mb={4}
             borderLeftWidth={10}
-            borderLeftColor={report.status === 'ready' ? 'green' : 'gray'}
+            borderLeftColor={
+              report.status === 'ready' ? 'green' :
+                report.status === 'error' ? 'red.600' : 'gray'
+            }
           >
             <Card.Body>
               <HStack justify={'space-between'}>
                 <HStack>
-                  <Box mr={3} color={report.status === 'ready' ? 'green' : 'gray'}>
-                    {report.status === 'ready' ? (<CircleCheckIcon size={30}/>) : (
-                      <CircleFadingArrowUpIcon size={30}/>)}
+                  <Box mr={3} color={
+                    report.status === 'ready' ? 'green' :
+                      report.status === 'error' ? 'red.600' : 'gray'
+                  }>
+                    {report.status === 'ready' ? (<CircleCheckIcon size={30}/>) :
+                      report.status === 'error' ? (<CircleAlertIcon size={30}/>) :
+                        (<CircleFadingArrowUpIcon size={30}/>)}
                   </Box>
                   <Box>
                     <Card.Title>
                       <Text
                         fontSize={'md'}
-                        color={report.status === 'ready' ? '#2577b1' : 'gray'}
+                        color={
+                          report.status === 'ready' ? '#2577b1' :
+                            report.status === 'error' ? 'red.600' : 'gray'
+                        }
                       >{report.title}</Text>
                     </Card.Title>
                     <Card.Description>

--- a/client-admin/app/page.tsx
+++ b/client-admin/app/page.tsx
@@ -10,6 +10,33 @@ import {useEffect, useState} from 'react'
 
 export default function Page() {
   const [reports, setReports] = useState<Report[]>()
+
+  const getStatusDisplay = (status: string) => {
+    switch (status) {
+      case 'ready':
+        return {
+          borderColor: 'green',
+          iconColor: 'green',
+          textColor: '#2577b1',
+          icon: <CircleCheckIcon size={30}/>
+        }
+      case 'error':
+        return {
+          borderColor: 'red.600',
+          iconColor: 'red.600',
+          textColor: 'red.600',
+          icon: <CircleAlertIcon size={30}/>
+        }
+      default:
+        return {
+          borderColor: 'gray',
+          iconColor: 'gray',
+          textColor: 'gray',
+          icon: <CircleFadingArrowUpIcon size={30}/>
+        }
+    }
+  }
+
   useEffect(() => {
     (async () => {
       const response = await fetch(process.env.NEXT_PUBLIC_API_BASEPATH + '/admin/reports', {
@@ -40,74 +67,67 @@ export default function Page() {
             <Text>レポートがありません</Text>
           </VStack>
         )}
-        {reports && reports.map(report => (
-          <Card.Root
-            size="md"
-            key={report.slug}
-            mb={4}
-            borderLeftWidth={10}
-            borderLeftColor={
-              report.status === 'ready' ? 'green' :
-                report.status === 'error' ? 'red.600' : 'gray'
-            }
-          >
-            <Card.Body>
-              <HStack justify={'space-between'}>
-                <HStack>
-                  <Box mr={3} color={
-                    report.status === 'ready' ? 'green' :
-                      report.status === 'error' ? 'red.600' : 'gray'
-                  }>
-                    {report.status === 'ready' ? (<CircleCheckIcon size={30}/>) :
-                      report.status === 'error' ? (<CircleAlertIcon size={30}/>) :
-                        (<CircleFadingArrowUpIcon size={30}/>)}
-                  </Box>
-                  <Box>
-                    <Card.Title>
-                      <Text
-                        fontSize={'md'}
-                        color={
-                          report.status === 'ready' ? '#2577b1' :
-                            report.status === 'error' ? 'red.600' : 'gray'
-                        }
-                      >{report.title}</Text>
-                    </Card.Title>
-                    <Card.Description>
-                      {`${process.env.NEXT_PUBLIC_CLIENT_BASEPATH}/${report.slug}`}
-                    </Card.Description>
-                  </Box>
+        {reports && reports.map(report => {
+          const statusDisplay = getStatusDisplay(report.status)
+
+          return (
+            <Card.Root
+              size="md"
+              key={report.slug}
+              mb={4}
+              borderLeftWidth={10}
+              borderLeftColor={statusDisplay.borderColor}
+            >
+              <Card.Body>
+                <HStack justify={'space-between'}>
+                  <HStack>
+                    <Box mr={3} color={statusDisplay.iconColor}>
+                      {statusDisplay.icon}
+                    </Box>
+                    <Box>
+                      <Card.Title>
+                        <Text
+                          fontSize={'md'}
+                          color={statusDisplay.textColor}
+                        >{report.title}</Text>
+                      </Card.Title>
+                      <Card.Description>
+                        {`${process.env.NEXT_PUBLIC_CLIENT_BASEPATH}/${report.slug}`}
+                      </Card.Description>
+                    </Box>
+                  </HStack>
+                  <HStack>
+                    {report.status === 'ready' && (
+                      <Link href={`${process.env.NEXT_PUBLIC_CLIENT_BASEPATH}/${report.slug}`} target={'_blank'}>
+                        <Button variant={'ghost'}>
+                          <ExternalLinkIcon/>
+                        </Button>
+                      </Link>
+                    )}
+                    <MenuRoot>
+                      <MenuTrigger asChild>
+                        <Button variant="ghost" size="lg">
+                          <EllipsisIcon/>
+                        </Button>
+                      </MenuTrigger>
+                      <MenuContent>
+                        <MenuItem value={'duplicate'}>
+                          レポートを複製して新規作成(開発中)
+                        </MenuItem>
+                        <MenuItem
+                          value="delete"
+                          color="fg.error"
+                        >
+                          レポートを削除する(開発中)
+                        </MenuItem>
+                      </MenuContent>
+                    </MenuRoot>
+                  </HStack>
                 </HStack>
-                <HStack>
-                  {report.status === 'ready' && (
-                    <Link href={`${process.env.NEXT_PUBLIC_CLIENT_BASEPATH}/${report.slug}`} target={'_blank'}>
-                      <Button variant={'ghost'}>
-                        <ExternalLinkIcon/>
-                      </Button>
-                    </Link>
-                  )}
-                  <MenuRoot>
-                    <MenuTrigger asChild>
-                      <Button variant="ghost" size="lg">
-                        <EllipsisIcon/>
-                      </Button>
-                    </MenuTrigger>
-                    <MenuContent>
-                      <MenuItem value={'duplicate'}>
-                        レポートを複製して新規作成(開発中)
-                      </MenuItem>
-                      <MenuItem
-                        value="delete"
-                        color="fg.error"
-                      >
-                        レポートを削除する(開発中)
-                      </MenuItem>
-                    </MenuContent>
-                  </MenuRoot>
-                </HStack>
-              </HStack>
-            </Card.Body>
-          </Card.Root>
-        ))}
+              </Card.Body>
+            </Card.Root>
+          )
+        })}
         <HStack justify={'center'} mt={10}>
           <Link href={'/create'}>
             <Button size={'xl'}>新しいレポートを作成する</Button>

--- a/server/broadlistening/pipeline/specs.json
+++ b/server/broadlistening/pipeline/specs.json
@@ -1,0 +1,119 @@
+[
+    {
+      "step": "extraction",
+      "filename": "args.csv",
+      "dependencies": {
+        "params": ["limit"],
+        "steps": []
+      },
+      "options": {
+        "limit": 1000,
+        "workers": 1,
+        "properties": [],
+        "categories": {},
+        "category_batch_size": 5
+      },
+      "use_llm": true
+    },
+    {
+      "step": "embedding",
+      "filename": "embeddings.pkl",
+      "dependencies": {
+        "params": ["model"],
+        "steps": ["extraction"]
+      },
+      "options": {
+        "model": "text-embedding-3-small"
+      }
+    },
+    {
+      "step": "clustering",
+      "filename": "clusters.csv",
+      "dependencies": {
+        "params": ["clusters"],
+        "steps": ["embedding"]
+      },
+      "options": {
+        "clusters": 8
+      }
+    },
+    {
+      "step": "labelling",
+      "filename": "labels.csv",
+      "dependencies": {
+        "params": ["sample_size"],
+        "steps": ["clustering"]
+      },
+      "options": {
+        "sample_size": 30
+      },
+      "use_llm": true
+    },
+    {
+      "step": "takeaways",
+      "filename": "takeaways.csv",
+      "dependencies": {
+        "params": ["sample_size"],
+        "steps": ["clustering"]
+      },
+      "options": {
+        "sample_size": 30
+      },
+      "use_llm": true
+    },
+    {
+      "step": "overview",
+      "filename": "overview.txt",
+      "dependencies": {
+        "params": [],
+        "steps": ["labelling", "takeaways"]
+      },
+      "options": {},
+      "use_llm": true
+    },
+    {
+      "step": "translation",
+      "filename": "translations.json",
+      "dependencies": {
+        "params": ["languages"],
+        "steps": ["extraction", "labelling", "takeaways", "overview"]
+      },
+      "options": {
+        "languages": [],
+        "flags": []
+      },
+      "use_llm": true
+    },
+    {
+      "step": "aggregation",
+      "filename": "result.json",
+      "dependencies": {
+        "params": [],
+        "steps": [
+          "extraction",
+          "clustering",
+          "labelling",
+          "takeaways",
+          "overview",
+          "translation"
+        ]
+      },
+      "options": {
+        "include_minor": true,
+        "sampling_num": 5000,
+        "title_in_map": null,
+        "hidden_properties": {}
+      }
+    },
+    {
+      "step": "visualization",
+      "filename": "report",
+      "dependencies": {
+        "params": ["replacements"],
+        "steps": ["aggregation"]
+      },
+      "options": {
+        "replacements": []
+      }
+    }
+  ]


### PR DESCRIPTION
# 変更の概要
バックエンド側のステータス変更については問題なさそうでしたが、レポート一覧画面でレポート生成失敗時の表示に関する定義がなかったため、追加してみました。
CircleAlertIcon やカラーコードは仮で入れてみたので、違和感あるようであれば適宜修正いただけると幸いです。

# 変更の背景
#47 

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました