### PR TITLE
視認性の高い配色、アノテーションに変更

### DIFF
--- a/client/components/charts/ScatterChart.tsx
+++ b/client/components/charts/ScatterChart.tsx
@@ -10,7 +10,7 @@ type Props = {
 
 export function ScatterChart({clusterList, argumentList, targetLevel}: Props) {
   const targetClusters = clusterList.filter((cluster) => cluster.level === targetLevel)
-  const softColors = ['#b3daa1', '#f5c5d7', '#d5e5f0', '#fbecc0', '#80b8ca', '#dabeed', '#fad1af', '#fbb09d', '#a6e3ae', '#f1e4d6']
+  const softColors = ['#7ac943', '#3fa9f5', '#ff7997', '#e0dd02', '#d6410f', '#b39647', '#7cccc3', '#a147e6']
   const clusterColorMap = targetClusters.reduce((acc, cluster, index) => {
     acc[cluster.id] = softColors[index % softColors.length]
     return acc
@@ -77,12 +77,15 @@ export function ScatterChart({clusterList, argumentList, targetLevel}: Props) {
           text: data.cluster.label,
           showarrow: false,
           font: {
-            color: '#2577b1',
+            color: 'white',
             size: 14,
             weight: 700,
           },
-          bgcolor: '#fff',
+          bgcolor: clusterColorMap[data.cluster.id],
           opacity: 0.8,
+          bordercolor: clusterColorMap[data.cluster.id],
+          borderpad: 4,
+          borderwidth: 1,
         })),
         showlegend: false,
       }}


### PR DESCRIPTION
# 変更の概要
色盲の方でも視認性の高いチャート配色にするため、各クラスタとアノテーションラベルのカラーコードの指定をするようにしました。

アノテーションラベルについては、borderRadius の指定をする方法を見つけられなかったので一旦指定しない状態にしてみています。
https://plotly.com/javascript/reference/layout/annotations/

![Screenshot-scatterchart-color](https://github.com/user-attachments/assets/09a5a201-6cd1-46c0-aeec-2871e22fa1d8)

# 変更の背景
#51 

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/takahiroanno2024/kouchou-ai/blob/main/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました