### PR TITLE
docker-compose.override.y*ml の利用

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .next
 .DS_Store
 node_modules
+docker-compose.override.y*ml


### PR DESCRIPTION
# 変更の概要
- .gitignore に docker-compose.override.y*ml を追加

# 変更の背景
開発中に自分の手元の開発環境だけ異なった設定にしたい場合に、[docker-compose.override.yamlの仕組み](https://matsuand.github.io/docs.docker.jp.onthefly/compose/extends/#example-use-case) が使えそうだと思い、上記変更を提案します。

例えば、手元に以下の `docker-compose.override.yaml` というファイルを作って使うイメージです。
```yaml:docker-compose.override.yaml
services:
  client:
    command: npm run dev
    volumes:
      - ./client:/app
      - /app/node_modules

  client-admin:
    command: npm run dev
    volumes:
      - ./client-admin:/app
      - /app/node_modules
```

私の動機は、開発環境ではコード変更時に自動で build してほしかったというものなのですが、この言語での開発に不慣れで他の方法が思いつかなかったので、もし他に良い方法があればそちらでも構いません。
教えていただけると幸いです。

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/takahiroanno2024/kouchou-ai/blob/main/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました