### PR TITLE
package-lock.json の name を修正する

### DIFF
--- a/client-admin/package-lock.json
+++ b/client-admin/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "shotokutaishi-client-admin",
+  "name": "kouchou-ai-client-admin",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "shotokutaishi-client-admin",
+      "name": "kouchou-ai-client-admin",
       "version": "0.1.0",
       "dependencies": {
         "@chakra-ui/react": "^3.5.1",

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "shotokutaishi-client",
+  "name": "kouchou-ai-client",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "shotokutaishi-client",
+      "name": "kouchou-ai-client",
       "version": "0.1.0",
       "dependencies": {
         "@chakra-ui/react": "^3.5.1",


### PR DESCRIPTION
# 変更の概要
- client, client-admin 内の package-lock.json の `name` の内容が、package.json と異なっていたので修正しました

# 変更の背景
- https://github.com/takahiroanno2024/kouchou-ai/pull/33 で名称を変更した際の変更漏れだと思います

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/takahiroanno2024/kouchou-ai/blob/main/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました